### PR TITLE
Render pretty Events list from ICS feed

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,10 @@
 name: Deploy Jekyll site to Pages
 
 on:
+  # Runs daily at 2:17 am
+  schedule:
+     - cron: "17 2 * * *"
+
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
@@ -43,6 +47,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      - name: Install dependencies
+        run: gem install jekyll-ical-tag
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ plugins:
 - jekyll-feed
 - jekyll-seo-tag
 - jekyll-redirect-from
+- jekyll-ical-tag
 description: Safe Streets Halton is a grass-roots organization on a mission to eliminate
   all traffic-related deaths and serious injuries in Halton, Ontario.
 baseurl: 

--- a/events/index.md
+++ b/events/index.md
@@ -2,8 +2,53 @@
 title: Events
 permalink: "/events/"
 layout: page
+icalfeed: https://calendar.google.com/calendar/ical/926ec19eafe787c87e14dd080b121ffda8227a8fc9d5f5fbfeb2c8097f5468df%40group.calendar.google.com/public/basic.ics
+
 ---
 
-<section>
-<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=America%2FToronto&mode=AGENDA&title=Events&showPrint=0&src=OTI2ZWMxOWVhZmU3ODdjODdlMTRkZDA4MGIxMjFmZmRhODIyN2E4ZmM5ZDVmNWZiZmViMmM4MDk3ZjU0NjhkZkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23ef6c00" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
-</section>
+{% assign approx_one_year_in_future = "now"
+    | date: "%s"
+    | plus: 31536000
+    | date: "%Y-%m-%d" %}
+
+{% ical url: {{page.icalfeed}} reverse: false only_future: true before_date: {{approx_one_year_in_future}} %}
+
+{% comment %}
+  Note:
+   Compute a duration, and render it if between 30-120 minutes.
+   Otherwise assume the duration in event is a mistake.
+{% endcomment %}
+{% assign dtend = event.end_time | date: "%s" %}
+{% assign dtstart = event.start_time | date: "%s" %}
+{% assign duration_seconds = dtend | minus: dtstart %}
+{% assign duration_minutes = duration_seconds | divided_by: 60 %}
+
+## {{ event.summary }}
+
+* {{ event.start_time | date: "%A %F %l:%M %p" }}
+{% if duration_minutes >= 30 and duration_minutes < 120 -%}
+* Duration: {{ duration_minutes }} minutes
+{% endif -%}
+{% if event.location -%}
+* Location:
+<span class="adr">{{ event.location | replace: ", Canada", "" }}</span>
+    —
+    <small>
+    [OpenStreetMap](https://www.openstreetmap.org/search?query={{ event.location | uri_escape }}&minlon=-80.44941172485548&minlat=43.270554613257694&maxlon=-79.33223948364454&maxlat=43.749618848985655#layers=YNG) |
+    [Google Maps](https://www.google.com/maps/search/?api=1&query={{ event.location | uri_escape }}) |
+    [Apple Maps](https://maps.apple.com/place?address={{ event.location | uri_escape }})
+    </small>
+{%- endif %}
+
+{{ event.simple_html_description | newline_to_br }}
+
+{% if event.url contains 'https://www.eventbrite.ca/' %}
+[RSVP]({{ event.url }}){: .btn-primary }
+{% endif %}
+
+
+{% endical %}
+
+---
+
+[Subscribe to calendar feed for future events]({{page.icalfeed}})


### PR DESCRIPTION
Daily, retrieve public google calendar ICS feed, and render a pretty list of events.

Replaces embedded google calendar (iframe) UI with our own styles, but maintains use of google calendar for management of events.

Add dependency: Jekyll plugin jekyll-ical-tag